### PR TITLE
Fix/1 config recording bug

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -250,6 +250,8 @@ class ConfigEditor:
         "conversation",
         "imagine",
         "shortcuts",
+        "voice",
+        "files",
     ]
     # Changes made to these properties take effect after a restart.
     delayed = [
@@ -269,12 +271,12 @@ class ConfigEditor:
         """Returns a config property value."""
         names = property.split(".")
         if names[0] not in self.known:
-            raise ValueError(f"No such property: {property}")
+            raise ValueError(f"No such property in known: {property}")
 
         obj = self.config
         for name in names[:-1]:
             if not hasattr(obj, name):
-                raise ValueError(f"No such property: {property}")
+                raise ValueError(f"No such property in attrs: {property}")
             obj = getattr(obj, name)
 
         name = names[-1]

--- a/bot/config.py
+++ b/bot/config.py
@@ -219,7 +219,10 @@ class Config:
         return {
             "schema_version": self.schema_version,
             "telegram": dataclasses.asdict(self.telegram),
+            "scrapdo": dataclasses.asdict(self.scrapdo),
             "openai": dataclasses.asdict(self.openai),
+            "voice": dataclasses.asdict(self.voice),
+            "files": dataclasses.asdict(self.files),
             "conversation": dataclasses.asdict(self.conversation),
             "imagine": dataclasses.asdict(self.imagine),
             "persistence_path": self.persistence_path,


### PR DESCRIPTION
- Add voice and files to immediate properties list in ConfigEditor
- Update error messages to be more specific about property location
- ⚠️ Fix config serialization to include voice and files settings 

This change allows managing voice and file settings through /config command,
including nested properties like voice.tts_enabled and voice.tts.voice.