### PR TITLE
Fix config default and improve question extraction

### DIFF
--- a/bot/commands/message.py
+++ b/bot/commands/message.py
@@ -73,7 +73,7 @@ class MessageCommand:
         if message.chat.type == Chat.PRIVATE:
             question = await questions.extract_private(message, context)
         else:
-            question = await questions.extract_group(message, context)
+            question, message = await questions.extract_group(message, context)
 
             # Если это ответ с упоминанием бота на сообщение с файлом/голосовым
             if (

--- a/bot/config.py
+++ b/bot/config.py
@@ -190,7 +190,7 @@ class Config:
         )
 
         self.scrapdo = Scrapdo(
-            token=src["scrapdo"]["token"],
+            token=src.get("scrapdo", {}).get("token", ""),
         )
 
         # Conversation settings.

--- a/bot/filters.py
+++ b/bot/filters.py
@@ -69,11 +69,10 @@ class Filters:
         if not entities:
             return False
 
+        source = message.text if message.text is not None else message.caption or ""
         for entity in entities:
             if entity.type == MessageEntity.MENTION:
-                mention_text = message.text[
-                    entity.offset : entity.offset + entity.length
-                ]
+                mention_text = source[entity.offset : entity.offset + entity.length]
                 if mention_text.lower() == f"@{bot_username.lower()}":
                     return True
         return False


### PR DESCRIPTION
## Summary
- avoid KeyError when `scrapdo` section is missing
- correctly detect bot mentions inside captions
- return reply target from `extract_group` and handle documents
- adapt message handler to new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684041b16d3c832c8c51838de2def49e