### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ⚠️ It is fork of [pokitoki](https://github.com/nalgeon/pokitoki) with additional features
 
-- Here is available web-sites scrapping via scrape.do API (provides 1000 requests/mo for free )
-- Voice messsages support, with optional TTS-output (hear answer instead of reading).
+- Supports website scraping via scrape.do API (provides 1000 requests/mo for free)
+- Voice messages support, with optional TTS-output (hear answer instead of reading).
 - Documents support.
 
 


### PR DESCRIPTION
## Summary
- fix `scrapping` typo
- fix `messsages` typo
- rewrite bullet about site scraping for clarity

## Testing
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'tiktoken', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68404f5e42ec832cb32c37615e021242