### PR TITLE
Switch default prompt role to system

### DIFF
--- a/bot/ai/chatgpt.py
+++ b/bot/ai/chatgpt.py
@@ -60,7 +60,7 @@ class Model:
     ) -> str:
         """Asks the language model a question and returns an answer."""
         model = self.name or config.openai.model
-        prompt_role = ROLE_OVERRIDES.get(model) or "developer"
+        prompt_role = ROLE_OVERRIDES.get(model) or "system"
         params_func = PARAM_OVERRIDES.get(model) or (lambda params: params)
 
         n_input = _calc_n_input(model, n_output=config.openai.params["max_tokens"])

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -12,11 +12,11 @@ class ModelTest(unittest.TestCase):
     def test_generate_messages(self):
         history = [UserMessage("Hello", "Hi"), UserMessage("Is it cold today?", "Yep!")]
         messages = self.model._generate_messages(
-            prompt_role="developer", prompt="", question="What's your name?", history=history
+            prompt_role="system", prompt="", question="What's your name?", history=history
         )
         self.assertEqual(len(messages), 6)
 
-        self.assertEqual(messages[0]["role"], "developer")
+        self.assertEqual(messages[0]["role"], "system")
         self.assertEqual(messages[0]["content"], config.openai.prompt)
 
         self.assertEqual(messages[1]["role"], "user")


### PR DESCRIPTION
## Summary
- use `system` as the default role when building chat prompts
- update tests for new role name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fdbbdfa8832cad0c53b19e39a32b