### PR TITLE
Fix answer log length

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -302,7 +302,7 @@ async def _ask_question(
 
     logger.info(
         f"<- answer id={message.id}, user={user_id}, "
-        f"n_chars={len(question)}, len_history={len(history)}, took={elapsed}ms"
+        f"n_chars={len(answer)}, len_history={len(history)}, took={elapsed}ms"
     )
     return answer
 


### PR DESCRIPTION
## Summary
- fix n_chars in the answer log to report answer length

## Testing
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'tiktoken', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684309ed277c832c882fda2e25e7c7c9