### PR TITLE
Refactor AI modules and extend OpenAI settings

### DIFF
--- a/bot/ai/__init__.py
+++ b/bot/ai/__init__.py
@@ -1,1 +1,1 @@
-from . import chatgpt, dalle  # noqa: F401
+from . import chat, images  # noqa: F401

--- a/bot/ai/chat.py
+++ b/bot/ai/chat.py
@@ -8,7 +8,7 @@ from openai import AsyncOpenAI
 
 from bot.config import config
 
-openai = AsyncOpenAI(api_key=config.openai.api_key)
+openai = AsyncOpenAI(api_key=config.openai.api_key, base_url=config.openai.url)
 
 encoding = tiktoken.get_encoding("cl100k_base")
 logger = logging.getLogger(__name__)

--- a/bot/ai/images.py
+++ b/bot/ai/images.py
@@ -4,7 +4,7 @@ from openai import AsyncOpenAI
 
 from bot.config import config
 
-openai = AsyncOpenAI(api_key=config.openai.api_key)
+openai = AsyncOpenAI(api_key=config.openai.api_key, base_url=config.openai.url)
 
 
 class Model:
@@ -12,7 +12,9 @@ class Model:
 
     async def imagine(self, prompt: str, size: str) -> str:
         """Generates an image of the specified size according to the description."""
-        resp = await openai.images.generate(model="dall-e-3", prompt=prompt, size=size, n=1)
-        if len(resp.data) == 0:
-            raise ValueError("received an empty answer")
+        resp = await openai.images.generate(
+            model=config.openai.image_model, prompt=prompt, size=size, n=1
+        )
+        if not getattr(resp, "data", None):
+            raise Exception("missing image data")
         return resp.data[0].url

--- a/bot/askers.py
+++ b/bot/askers.py
@@ -29,7 +29,7 @@ class Asker:
 class TextAsker(Asker):
     """Works with chat completion AI."""
 
-    model = ai.chatgpt.Model()
+    model = ai.chat.Model()
 
     async def ask(self, prompt: str, question: str, history: list[tuple[str, str]]) -> str:
         """Asks AI a question."""
@@ -60,7 +60,7 @@ class TextAsker(Asker):
 class ImagineAsker(Asker):
     """Works with image generation AI."""
 
-    model = ai.dalle.Model()
+    model = ai.images.Model()
     size_re = re.compile(r"(256|512|1024)(?:x\1)?\s?(?:px)?")
     sizes = {
         "256": "256x256",

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -34,7 +34,7 @@ logging.basicConfig(
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("openai").setLevel(logging.WARNING)
 logging.getLogger("bot").setLevel(logging.INFO)
-logging.getLogger("bot.ai.chatgpt").setLevel(logging.INFO)
+logging.getLogger("bot.ai.chat").setLevel(logging.INFO)
 logging.getLogger("bot.commands").setLevel(logging.INFO)
 logging.getLogger("bot.questions").setLevel(logging.INFO)
 logging.getLogger("__main__").setLevel(logging.INFO)

--- a/bot/cli.py
+++ b/bot/cli.py
@@ -10,7 +10,7 @@ import os
 import sys
 import textwrap
 
-import bot.ai.chatgpt
+import bot.ai.chat
 from bot.config import config
 from bot.fetcher import Fetcher
 
@@ -29,7 +29,7 @@ async def main(question):
 
 def init_model():
     name = os.getenv("OPENAI_MODEL") or config.openai.model
-    return bot.ai.chatgpt.Model(name)
+    return bot.ai.chat.Model(name)
 
 
 if __name__ == "__main__":

--- a/bot/config.py
+++ b/bot/config.py
@@ -28,6 +28,8 @@ class OpenAI:
     window: int
     prompt: str
     params: dict
+    url: str
+    image_model: str
 
     default_model = "gpt-4o-mini"
     default_window = 4096
@@ -38,6 +40,8 @@ class OpenAI:
         "frequency_penalty": 0,
         "max_tokens": 1000,
     }
+    default_url = "https://api.openai.com/v1"
+    default_image_model = "dall-e-3"
 
     def __init__(
         self,
@@ -46,6 +50,8 @@ class OpenAI:
         window: int,
         prompt: str,
         params: dict,
+        url: str = default_url,
+        image_model: str = default_image_model,
     ) -> None:
         self.api_key = api_key
         self.model = model or self.default_model
@@ -53,6 +59,8 @@ class OpenAI:
         self.prompt = prompt or self.default_prompt
         self.params = self.default_params.copy()
         self.params.update(params)
+        self.url = url or self.default_url
+        self.image_model = image_model or self.default_image_model
 
 
 @dataclass
@@ -183,6 +191,8 @@ class Config:
             window=src["openai"].get("window"),
             prompt=src["openai"].get("prompt"),
             params=src["openai"].get("params") or {},
+            url=src["openai"].get("url"),
+            image_model=src["openai"].get("image_model"),
         )
 
         self.scrapdo = Scrapdo(

--- a/bot/voice.py
+++ b/bot/voice.py
@@ -24,7 +24,9 @@ class VoiceProcessor:
         self.max_file_size = (
             config.voice.max_file_size * 1024 * 1024
         )  # Convert MB to bytes
-        self.client = AsyncOpenAI(api_key=config.openai.api_key)
+        self.client = AsyncOpenAI(
+            api_key=config.openai.api_key, base_url=config.openai.url
+        )
 
     async def transcribe(self, voice_file: Path) -> Optional[str]:
         """Transcribes voice message to text using Whisper API."""

--- a/config.example.yml
+++ b/config.example.yml
@@ -29,9 +29,15 @@ openai:
     # OpenAI API key.
     api_key: ""
 
+    # OpenAI API base URL.
+    url: "https://api.openai.com/v1"
+
     # OpenAI model name.
     # See https://platform.openai.com/docs/models for description.
     model: "gpt-4o-mini"
+
+    # Image generation model name.
+    image_model: "dall-e-3"
 
     # Context window size in tokens.
     window: 4096

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,13 +1,13 @@
 import unittest
 
-from bot.ai import chatgpt
+from bot.ai import chat
 from bot.config import config
 from bot.models import UserMessage
 
 
 class ModelTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.model = chatgpt.Model()
+        self.model = chat.Model()
 
     def test_generate_messages(self):
         history = [UserMessage("Hello", "Hi"), UserMessage("Is it cold today?", "Yep!")]
@@ -41,7 +41,7 @@ class ShortenTest(unittest.TestCase):
             {"role": "system", "content": "You are an AI assistant."},
             {"role": "user", "content": "Hello"},
         ]
-        shortened = chatgpt.shorten(messages, length=11)
+        shortened = chat.shorten(messages, length=11)
         self.assertEqual(shortened, messages)
 
     def test_remove_messages_1(self):
@@ -51,7 +51,7 @@ class ShortenTest(unittest.TestCase):
             {"role": "assistant", "content": "My name is Alice."},
             {"role": "user", "content": "Is it cold today?"},
         ]
-        shortened = chatgpt.shorten(messages, length=11)
+        shortened = chat.shorten(messages, length=11)
         self.assertEqual(
             shortened,
             [
@@ -67,7 +67,7 @@ class ShortenTest(unittest.TestCase):
             {"role": "assistant", "content": "My name is Alice."},
             {"role": "user", "content": "Is it cold today?"},
         ]
-        shortened = chatgpt.shorten(messages, length=20)
+        shortened = chat.shorten(messages, length=20)
         self.assertEqual(
             shortened,
             [
@@ -82,7 +82,7 @@ class ShortenTest(unittest.TestCase):
             {"role": "system", "content": "You are an AI assistant."},
             {"role": "user", "content": "Is it cold today? I think it's rather cold"},
         ]
-        shortened = chatgpt.shorten(messages, length=11)
+        shortened = chat.shorten(messages, length=11)
         self.assertEqual(
             shortened,
             [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,8 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config.openai.params["presence_penalty"], 0)
         self.assertEqual(config.openai.params["frequency_penalty"], 0)
         self.assertEqual(config.openai.params["max_tokens"], 1000)
+        self.assertEqual(config.openai.url, "https://api.openai.com/v1")
+        self.assertEqual(config.openai.image_model, "dall-e-3")
 
         self.assertEqual(config.conversation.depth, 5)
         self.assertEqual(config.imagine.enabled, "none")
@@ -47,6 +49,8 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(data["telegram"]["chat_ids"], [])
         self.assertEqual(data["openai"]["api_key"], src["openai"]["api_key"])
         self.assertEqual(data["openai"]["model"], src["openai"]["model"])
+        self.assertEqual(data["openai"]["url"], "https://api.openai.com/v1")
+        self.assertEqual(data["openai"]["image_model"], "dall-e-3")
         self.assertEqual(data["conversation"]["depth"], src["conversation"]["depth"])
         self.assertEqual(data["imagine"]["enabled"], src["imagine"]["enabled"])
 


### PR DESCRIPTION
## Summary
- rename `chatgpt` -> `chat` and `dalle` -> `images`
- add `url` and `image_model` options to `OpenAI` config
- send `base_url` when creating OpenAI clients
- support configurable image model and handle missing data
- document new configuration fields
- update tests for renamed modules and new fields

## Testing
- `CONFIG=config.example.yml pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68431e11f048832ca74ef44544b7f881