### PR TITLE
Add o3-mini model support

### DIFF
--- a/bot/ai/chatgpt.py
+++ b/bot/ai/chatgpt.py
@@ -18,6 +18,7 @@ MODELS = {
     "o1": 200000,
     "o1-preview": 128000,
     "o1-mini": 128000,
+    "o3-mini": 200000,
     "gpt-4o": 128000,
     "gpt-4o-mini": 128000,
     "gpt-4-turbo": 128000,
@@ -33,12 +34,14 @@ ROLE_OVERRIDES = {
     "o1": "user",
     "o1-preview": "user",
     "o1-mini": "user",
+    "o3-mini": "user",
 }
 # Model parameter overrides.
 PARAM_OVERRIDES = {
     "o1": lambda params: {},
     "o1-preview": lambda params: {},
     "o1-mini": lambda params: {},
+    "o3-mini": lambda params: {},
 }
 
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -31,6 +31,7 @@ openai:
 
     # OpenAI model name.
     # See https://platform.openai.com/docs/models for description.
+    # The "o3-mini" model provides a 200k token context window.
     model: "gpt-4o-mini"
 
     # Context window size in tokens.


### PR DESCRIPTION
## Summary
- support `o3-mini` in AI model mappings
- mention the new model in example config

## Testing
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68430e9f03dc832c925917bf4f0163db