### PR TITLE
Update OpenAI defaults

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -30,13 +30,11 @@ class OpenAI:
     params: dict
 
     default_model = "gpt-4o-mini"
-    default_window = 4096
+    default_window = 128000
     default_prompt = "You are an AI assistant."
     default_params = {
         "temperature": 0.7,
-        "presence_penalty": 0,
-        "frequency_penalty": 0,
-        "max_tokens": 1000,
+        "max_tokens": 4096,
     }
 
     def __init__(

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,7 +1,7 @@
 # Bot configuration parameters.
 
 # Config schema version. Increments for backward-incompatible changes.
-schema_version: 3
+schema_version: 4
 
 # Telegram settings.
 telegram:
@@ -34,7 +34,7 @@ openai:
     model: "gpt-4o-mini"
 
     # Context window size in tokens.
-    window: 4096
+    window: 128000
 
     # Model prompt.
     prompt: "You are an AI assistant."
@@ -43,9 +43,7 @@ openai:
     # See https://platform.openai.com/docs/api-reference/chat/create for description.
     params:
         temperature: 0.7
-        presence_penalty: 0
-        frequency_penalty: 0
-        max_tokens: 1000
+        max_tokens: 4096
 
 
 conversation:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,12 +20,10 @@ class ConfigTest(unittest.TestCase):
 
         self.assertEqual(config.openai.api_key, "oa-1234")
         self.assertEqual(config.openai.model, "gpt-4")
-        self.assertEqual(config.openai.window, 4096)
+        self.assertEqual(config.openai.window, 128000)
         self.assertTrue(config.openai.prompt, "You are an AI assistant.")
         self.assertEqual(config.openai.params["temperature"], 0.7)
-        self.assertEqual(config.openai.params["presence_penalty"], 0)
-        self.assertEqual(config.openai.params["frequency_penalty"], 0)
-        self.assertEqual(config.openai.params["max_tokens"], 1000)
+        self.assertEqual(config.openai.params["max_tokens"], 4096)
 
         self.assertEqual(config.conversation.depth, 5)
         self.assertEqual(config.imagine.enabled, "none")


### PR DESCRIPTION
## Summary
- increase `default_window` for OpenAI models
- remove penalty parameters and raise `max_tokens` default
- keep the example config in sync
- adjust config tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430edbb708832c9b42cff971f0556f