### PR TITLE
Add o3-mini model support

### DIFF
--- a/bot/ai/chat.py
+++ b/bot/ai/chat.py
@@ -18,6 +18,7 @@ MODELS = {
     "o1": 200000,
     "o1-preview": 128000,
     "o1-mini": 128000,
+    "o3-mini": 200000,
     "gpt-4o": 128000,
     "gpt-4o-mini": 128000,
     "gpt-4-turbo": 128000,
@@ -33,12 +34,14 @@ ROLE_OVERRIDES = {
     "o1": "user",
     "o1-preview": "user",
     "o1-mini": "user",
+    "o3-mini": "user",
 }
 # Model parameter overrides.
 PARAM_OVERRIDES = {
     "o1": lambda params: {},
     "o1-preview": lambda params: {},
     "o1-mini": lambda params: {},
+    "o3-mini": lambda params: {},
 }
 
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -34,6 +34,7 @@ openai:
 
     # OpenAI model name.
     # See https://platform.openai.com/docs/models for description.
+    # Example: gpt-4o-mini, o3-mini
     model: "gpt-4o-mini"
 
     # Image generation model name.


### PR DESCRIPTION
## Summary
- support the `o3-mini` model in chat
- mention new model in example config

## Testing
- `python -m unittest discover` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68433daccfc4832c99d742b0b9fe6084