### PR TITLE
Add o3-mini model

### DIFF
--- a/bot/ai/chat.py
+++ b/bot/ai/chat.py
@@ -18,6 +18,7 @@ MODELS = {
     "o1": 200000,
     "o1-preview": 128000,
     "o1-mini": 128000,
+    "o3-mini": 200000,
     "gpt-4o": 128000,
     "gpt-4o-mini": 128000,
     "gpt-4-turbo": 128000,
@@ -33,12 +34,14 @@ ROLE_OVERRIDES = {
     "o1": "user",
     "o1-preview": "user",
     "o1-mini": "user",
+    "o3-mini": "user",
 }
 # Model parameter overrides.
 PARAM_OVERRIDES = {
     "o1": lambda params: {},
     "o1-preview": lambda params: {},
     "o1-mini": lambda params: {},
+    "o3-mini": lambda params: {},
 }
 
 


### PR DESCRIPTION
## Summary
- add new o3-mini model in `bot/ai/chat.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_68433e002d78832c9073bc121ba7ceeb