### PR TITLE
Update default OpenAI settings

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -32,13 +32,11 @@ class OpenAI:
     image_model: str
 
     default_model = "gpt-4o-mini"
-    default_window = 4096
+    default_window = 128000
     default_prompt = "You are an AI assistant."
     default_params = {
         "temperature": 0.7,
-        "presence_penalty": 0,
-        "frequency_penalty": 0,
-        "max_tokens": 1000,
+        "max_tokens": 4096,
     }
     default_url = "https://api.openai.com/v1"
     default_image_model = "dall-e-3"

--- a/config.example.yml
+++ b/config.example.yml
@@ -41,7 +41,7 @@ openai:
     image_model: "dall-e-3"
 
     # Context window size in tokens.
-    window: 4096
+    window: 128000
 
     # Model prompt.
     prompt: "You are an AI assistant."
@@ -50,9 +50,7 @@ openai:
     # See https://platform.openai.com/docs/api-reference/chat/create for description.
     params:
         temperature: 0.7
-        presence_penalty: 0
-        frequency_penalty: 0
-        max_tokens: 1000
+        max_tokens: 4096
 
 
 conversation:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,12 +20,10 @@ class ConfigTest(unittest.TestCase):
 
         self.assertEqual(config.openai.api_key, "oa-1234")
         self.assertEqual(config.openai.model, "gpt-4")
-        self.assertEqual(config.openai.window, 4096)
+        self.assertEqual(config.openai.window, 128000)
         self.assertTrue(config.openai.prompt, "You are an AI assistant.")
         self.assertEqual(config.openai.params["temperature"], 0.7)
-        self.assertEqual(config.openai.params["presence_penalty"], 0)
-        self.assertEqual(config.openai.params["frequency_penalty"], 0)
-        self.assertEqual(config.openai.params["max_tokens"], 1000)
+        self.assertEqual(config.openai.params["max_tokens"], 4096)
         self.assertEqual(config.openai.url, "https://api.openai.com/v1")
         self.assertEqual(config.openai.image_model, "dall-e-3")
 


### PR DESCRIPTION
## Summary
- expand OpenAI context window to `128000`
- raise `max_tokens` default to `4096`
- drop presence and frequency penalties
- update example configuration
- fix tests for new defaults

## Testing
- `CONFIG=/tmp/test_config.yml python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_68433eae69ec832cb96d6c85404b826b