### PR TITLE
Add provider info to version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Bot information:
 
 AI information:
 - model: gpt-3.5-turbo
+- provider: api.openai.com
 - history depth: 3
 - imagine: True
 - shortcuts: bugfix, proofread, summarize, translate

--- a/bot/commands/version.py
+++ b/bot/commands/version.py
@@ -3,6 +3,7 @@
 from telegram import Update
 from telegram.constants import ParseMode
 from telegram.ext import CallbackContext
+from urllib import parse
 
 from bot.config import config
 
@@ -46,10 +47,12 @@ class VersionCommand:
             text += f"\n\n{constants.PRIVACY_MESSAGE}"
 
         # AI information
+        provider = parse.urlparse(config.openai.url).hostname
         text += (
             "\n\n<pre>"
             "AI information:\n"
             f"- model: {config.openai.model}\n"
+            f"- provider: {provider}\n"
             f"- history depth: {config.conversation.depth}\n"
             f"- imagine: {config.imagine.enabled}\n"
             f"- shortcuts: {', '.join(config.shortcuts.keys())}"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -113,6 +113,7 @@ class VersionTest(unittest.IsolatedAsyncioTestCase, Helper):
 
         self.assertTrue("<pre>AI information:" in self.bot.text)
         self.assertTrue("- model: gpt-4" in self.bot.text)
+        self.assertTrue("- provider: api.openai.com" in self.bot.text)
         self.assertTrue("- history depth: 10" in self.bot.text)
         self.assertTrue("- imagine: none" in self.bot.text)
         self.assertTrue("- shortcuts: translate_en, translate_fr" in self.bot.text)


### PR DESCRIPTION
## Summary
- show provider hostname in the `/version` command output
- expect provider line in tests
- document provider in README example

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684340b332bc832cbd6d3d0532c352bd