### PR TITLE
Return HTML attachment for long answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ To ask a question about a document, send it as a file and write the question in 
 
 ### Reply with attachment
 
-Sometimes the AI's reply exceeds the maximum message length set by Telegram. In this case, the bot will not fail or spam you with messages. Instead, it will send the answer as an attached markdown file.
+Sometimes the AI's reply exceeds the maximum message length set by Telegram. In this case, the bot will not fail or spam you with messages. Instead, it will send the answer as attached Markdown and HTML files.
 
 ### Edited question
 

--- a/bot/askers.py
+++ b/bot/askers.py
@@ -42,17 +42,25 @@ class TextAsker(Asker):
             await message.reply_text(html_answer, parse_mode=ParseMode.HTML)
             return
 
-        doc = io.StringIO(answer)
         caption = (
             textwrap.shorten(answer, width=255, placeholder="...")
             + " (see attachment for the rest)"
         )
         reply_to_message_id = message.id if message.chat.type != Chat.PRIVATE else None
+        md_doc = io.StringIO(answer)
         await context.bot.send_document(
             chat_id=message.chat_id,
             caption=caption,
             filename=f"{message.id}.md",
-            document=doc,
+            document=md_doc,
+            reply_to_message_id=reply_to_message_id,
+        )
+        html_doc = io.StringIO(html_answer)
+        await context.bot.send_document(
+            chat_id=message.chat_id,
+            caption=caption,
+            filename=f"{message.id}.html",
+            document=html_doc,
             reply_to_message_id=reply_to_message_id,
         )
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -51,6 +51,7 @@ class FakeBot:
             can_read_all_group_messages=True,
         )
         self.text = ""
+        self.documents: list[tuple[str, str]] = []
 
     @property
     def username(self) -> str:
@@ -77,6 +78,7 @@ class FakeBot:
         self, chat_id: int, document: object, caption: str, filename: str, **kwargs
     ) -> None:
         self.text = f"{caption}: {filename}"
+        self.documents.append((caption, filename))
 
     async def send_photo(self, chat_id: int, photo: str, caption: str = None, **kwargs) -> None:
         self.text = f"{caption}: {photo}"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -373,7 +373,11 @@ class MessageTest(unittest.IsolatedAsyncioTestCase, Helper):
     async def test_document(self):
         update = self._create_update(11, text="I have so much to say" + "." * 5000)
         await self.command(update, self.context)
-        self.assertEqual(self.bot.text, "I have so much to... (see attachment for the rest): 11.md")
+        caption = "I have so much to... (see attachment for the rest)"
+        self.assertEqual(
+            self.bot.documents,
+            [(caption, "11.md"), (caption, "11.html")],
+        )
 
     async def test_exception(self):
         askers.TextAsker.model = FakeGPT(error=Exception("connection timeout"))


### PR DESCRIPTION
## Summary
- send both markdown and HTML files when a text reply is too long
- track multiple documents in tests via `FakeBot`
- update README to reflect attachment behavior
- test that two documents are sent

## Testing
- `CONFIG=config.example.yml pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433bec1b58832c8df1db6c6b364462