### PR TITLE
Add Gemini model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Humble GPT Telegram Bot
 
-This is a Telegram chat bot (AI assistant) that uses the GPT language models from OpenAI.
+This is a Telegram chat bot (AI assistant) that uses large language models from OpenAI-compatible providers (like [OpenAI](https://platform.openai.com/), [OpenRouter](https://openrouter.ai/docs/), [Nebius](https://docs.nebius.com/) or [Gemini](https://ai.google.dev/gemini-api/docs/openai)).
 
 Notable features:
 

--- a/bot/ai/chat.py
+++ b/bot/ai/chat.py
@@ -15,6 +15,12 @@ logger = logging.getLogger(__name__)
 
 # Supported models and their context windows
 MODELS = {
+    # Gemini
+    "gemini-2.0-flash": 1_048_576,
+    "gemini-1.5-flash": 1_048_576,
+    "gemini-1.5-flash-8b": 1_048_576,
+    "gemini-1.5-pro": 2_097_152,
+    # OpenAI
     "o1": 200000,
     "o1-preview": 128000,
     "o1-mini": 128000,


### PR DESCRIPTION
## Summary
- mention OpenAI-compatible LLM providers (including Gemini) in the README
- add Gemini model context sizes in `bot/ai/chat.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843451f2208832c91bf2ab0507cce9e