### PR TITLE
Disable imagine by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Notable features:
 -   Direct questions, mentions, follow-ups.
 -   Access external links (articles, code, data).
 -   Shortcuts (custom AI commands).
--   Custom chat-wide prompts.
+-   Custom per-chat prompts and models.
 -   Image generation.
 -   On-the-fly configuration.
 
@@ -121,7 +121,9 @@ There are several built-in shortcuts:
 
 You can add your own shortcuts. See `config.example.yml` for details.
 
-## Chat-wide prompts
+## Per-chat settings
+
+### Prompt
 
 To set a custom prompt for the current chat, use the `/prompt` command:
 
@@ -131,7 +133,7 @@ To return to the default prompt, use `/prompt reset`.
 
 The `/prompt` command in group chats is only available to admins - users listed in the `telegram.admins` property.
 
-## Model selection
+### Model
 
 To change the model for the current chat, use the `/model` command:
 
@@ -140,21 +142,6 @@ To change the model for the current chat, use the `/model` command:
 To return to the default model, use `/model reset`.
 
 Only admins - users listed in the `telegram.admins` property - can change the model in any chat.
-
-## Image generation
-
-Use the `/imagine` command to generate an image using the DALL-E 3 model from OpenAI:
-
-> 🧑 /imagine the dawn of a new era
->
-> 🤖 (beautiful picture)<br>
-> the dawn of a new era
-
-The default image size is 1024×1024 px. Other supported sizes are 1792×1024 and 1024×1792:
-
-> /imagine a lazy cat on a sunny day 1792×1024
-
-Image generation is quite pricey. By default it's only enabled for users listed in `telegram.usernames`, not for group members. You can change this with the `imagine.enabled` config property.
 
 ## Other useful features
 
@@ -196,11 +183,10 @@ Bot information:
 - access to messages: True
 
 AI information:
-- model: gpt-3.5-turbo
+- model: gpt-4o-mini
 - provider: api.openai.com
-- history depth: 3
-- imagine: True
-- shortcuts: bugfix, proofread, summarize, translate
+- history depth: 5
+- shortcuts: proofread, summarize
 ```
 
 ## Configuration
@@ -209,7 +195,6 @@ Use the `/config` command to change almost any setting on the fly, without resta
 
 -   Add or remove users and chats allowed to interact with the bot (`telegram.usernames` and `telegram.chat_ids`).
 -   Adjust the AI model (`openai.model`), prompt (`openai.prompt`) and params (`openai.params`).
--   Enable or disable image generation (`imagine.enabled`).
 -   Add or change AI shortcuts (`shortcuts`).
 -   Change any other config property.
 
@@ -218,7 +203,6 @@ To view a specific config property, put its name after `/config`:
 ```
 /config telegram.usernames
 /config openai.prompt
-/config imagine.enabled
 ```
 
 To change a specific config property, put its name and value after `/config`:
@@ -226,7 +210,6 @@ To change a specific config property, put its name and value after `/config`:
 ```
 /config telegram.usernames ["alice", "bob", "cindy"]
 /config openai.prompt "You are an evil AI bot"
-/config imagine.enabled none
 ```
 
 When working with list properties like `telegram.usernames`, you can add or remove individual items instead of redefining the whole list:
@@ -297,7 +280,7 @@ docker compose stop
 To update the bot to a new version:
 
 ```bash
-docker compose stop
+docker compose down
 git pull
 docker compose up --build --detach
 ```
@@ -337,11 +320,7 @@ python -m bot.bot
 
 ## Contributing
 
-For new features and improvements, please first open an issue to discuss what you would like to change.
-
-Be sure to add or update tests as appropriate.
-
-Use [Black](https://black.readthedocs.io/en/stable/) for code formatting and [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages.
+Contributions are welcome. For anything other than bugfixes, please first open an issue to discuss what you want to change. Use [Black](https://black.readthedocs.io/en/stable/) for code formatting. Be sure to add or update tests as appropriate.
 
 ## Changelog
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -99,7 +99,7 @@ class Imagine:
         self.enabled = (
             enabled
             if enabled in ("none", "users_only", "users_and_groups")
-            else "users_only"
+            else "none"
         )
 
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -73,7 +73,7 @@ imagine:
     #   - users_only       = enabled only for users listed in `telegram.usernames`
     #   - users_and_groups = enabled for both users listed in `telegram.usernames`
     #                        and members of `telegrams.chat_ids`
-    enabled: users_only
+    enabled: none
 
 # Where to store the chat context file.
 persistence_path: "./data/persistence.pkl"


### PR DESCRIPTION
## Summary
- default `Imagine.enabled` to `none`
- disable image generation in example config
- document per-chat settings and update snippets

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68435d352e6c832cb9d4d2146b392a83