### PR TITLE
Remove rust install from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /code
-# tiktoken comes precompiled only for 64 bit targets.
-# On other targets we have to compile it with rust
-RUN grep -q 64 /etc/apk/arch || { \
-    apk add cargo rust && \
-    rm /var/cache/apk/* ; }
 COPY ./requirements.txt .
 RUN pip3 install -r requirements.txt
 


### PR DESCRIPTION
## Summary
- strip cargo/rust build steps from Dockerfile

## Testing
- `docker-compose build` *(fails: Docker service unavailable)*
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_6844a501318c832cbddc2604afdd580d