### PR TITLE
Remove docker-compose note

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,6 @@ git pull
 docker compose up --build --detach
 ```
 
-For older Docker distributions, use `docker-compose` and specify the file: `docker-compose -f compose.yml up --build --detach`.
 
 ## Development setup
 


### PR DESCRIPTION
## Summary
- remove outdated docker-compose note from README

## Testing
- `python -m unittest discover` *(fails: FileNotFoundError: config.yml)*

------
https://chatgpt.com/codex/tasks/task_e_6847fa900cdc832c8b090480633a6a75