### PR TITLE
Handle media groups for file processing

### DIFF
--- a/bot/commands/message.py
+++ b/bot/commands/message.py
@@ -1,11 +1,12 @@
 """Text message handler."""
 
+import asyncio
 import logging
 from typing import Awaitable
 from pathlib import Path
 import tempfile
 
-from telegram import Chat, Update
+from telegram import Chat, Update, Message
 from telegram.ext import CallbackContext
 
 from bot import questions
@@ -25,6 +26,8 @@ class MessageCommand:
         self.reply_func = reply_func
         self.voice_processor = VoiceProcessor()
         self.filters = Filters()
+        self._media_buffers: dict[str, list[tuple[Update, Message]]] = {}
+        self._media_tasks: dict[str, asyncio.Task] = {}
 
     async def __call__(self, update: Update, context: CallbackContext) -> None:
         message = update.message or update.edited_message
@@ -35,7 +38,59 @@ class MessageCommand:
             f"voice={bool(message.voice)}, "
             f"document={message.document.file_name if message.document else None}, "
             f"photo={bool(message.photo)}, "
-            f"caption={bool(message.caption)}"
+            f"caption={bool(message.caption)}, "
+            f"media_group_id={message.media_group_id}"
+        )
+
+        if message.media_group_id:
+            key = message.media_group_id
+            self._media_buffers.setdefault(key, []).append((update, message))
+            if key not in self._media_tasks:
+                self._media_tasks[key] = asyncio.create_task(
+                    self._flush_media(key, context)
+                )
+            return
+
+        await self._process(update, context, message)
+
+    async def _flush_media(self, key: str, context: CallbackContext) -> None:
+        await asyncio.sleep(1)
+        data = self._media_buffers.pop(key, [])
+        self._media_tasks.pop(key, None)
+        if not data:
+            return
+        updates, messages = zip(*data)
+        update = updates[-1]
+        base = messages[-1]
+        docs: list = []
+        photos: list = []
+        texts: list[str] = []
+        for msg in messages:
+            if msg.document:
+                docs.append(msg.document)
+            if msg.photo:
+                photos.extend(msg.photo)
+            if msg.caption:
+                texts.append(msg.caption)
+            if msg.text:
+                texts.append(msg.text)
+        text = "\n".join(texts).strip() if texts else None
+        await self._process(update, context, base, docs, photos, text)
+
+    async def _process(
+        self,
+        update: Update,
+        context: CallbackContext,
+        message: Message,
+        documents: list | None = None,
+        photos: list | None = None,
+        text_override: str | None = None,
+    ) -> None:
+        logger.info(
+            f"Processing message: from={update.effective_user.username}, "
+            f"text={bool(text_override or message.text)}, "
+            f"voice={bool(message.voice)}, "
+            f"documents={len(documents or [])}, photos={len(photos or [])}"
         )
 
         # Проверяем, групповой ли это чат
@@ -58,71 +113,74 @@ class MessageCommand:
 
         # Обработка файлов
         file_content = None
-        if (message.document or message.photo) and config.files.enabled:
+        docs = documents or []
+        photos_list = photos or []
+        if (docs or photos_list) and config.files.enabled:
             if is_group and not is_reply_to_bot:
                 logger.info("Ignoring file in group chat - not a reply to bot")
                 return
 
             with FileProcessor() as file_processor:
                 file_content = await file_processor.process_files(
-                    documents=[message.document] if message.document else [],
-                    photos=message.photo if message.photo else [],
+                    documents=docs,
+                    photos=photos_list,
                 )
 
         # Получаем текст сообщения
-        if message.chat.type == Chat.PRIVATE:
-            question = await questions.extract_private(message, context)
+        if text_override is not None:
+            text_msg = Message(
+                message_id=message.message_id,
+                date=message.date,
+                chat=message.chat,
+                text=text_override,
+                from_user=message.from_user,
+                reply_to_message=message.reply_to_message,
+            )
+            text_msg.set_bot(context.bot)
         else:
-            question, message = await questions.extract_group(message, context)
+            text_msg = message
+
+        if text_msg.chat.type == Chat.PRIVATE:
+            question = await questions.extract_private(text_msg, context)
+        else:
+            question, text_msg = await questions.extract_group(text_msg, context)
 
             # Если это ответ с упоминанием бота на сообщение с файлом/голосовым
             if (
                 is_bot_mentioned
-                and message.reply_to_message
+                and text_msg.reply_to_message
                 and (
-                    message.reply_to_message.voice
-                    or message.reply_to_message.document
-                    or message.reply_to_message.photo
+                    text_msg.reply_to_message.voice
+                    or text_msg.reply_to_message.document
+                    or text_msg.reply_to_message.photo
                 )
             ):
-
-                if message.reply_to_message.voice:
-                    # Обработка голосового из reply
-                    voice_file = await message.reply_to_message.voice.get_file()
-                    with tempfile.NamedTemporaryFile(
-                        suffix=".ogg", delete=False
-                    ) as tmp_file:
+                if text_msg.reply_to_message.voice:
+                    voice_file = await text_msg.reply_to_message.voice.get_file()
+                    with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as tmp_file:
                         await voice_file.download_to_drive(tmp_file.name)
                         voice_path = Path(tmp_file.name)
 
-                    # Транскрибируем голосовое в текст
                     voice_content = await self.voice_processor.transcribe(voice_path)
-                    voice_path.unlink()  # Очищаем
+                    voice_path.unlink()
 
                     if voice_content:
                         file_content = voice_content
                     else:
-                        await message.reply_text(
+                        await text_msg.reply_text(
                             "Sorry, I couldn't understand the voice message."
                         )
                         return
 
-                elif (
-                    message.reply_to_message.document or message.reply_to_message.photo
-                ):
-                    # Обработка файла из reply
+                elif text_msg.reply_to_message.document or text_msg.reply_to_message.photo:
                     with FileProcessor() as file_processor:
                         file_content = await file_processor.process_files(
-                            documents=(
-                                [message.reply_to_message.document]
-                                if message.reply_to_message.document
-                                else []
-                            ),
-                            photos=(
-                                message.reply_to_message.photo
-                                if message.reply_to_message.photo
-                                else []
-                            ),
+                            documents=[text_msg.reply_to_message.document]
+                            if text_msg.reply_to_message.document
+                            else [],
+                            photos=text_msg.reply_to_message.photo
+                            if text_msg.reply_to_message.photo
+                            else [],
                         )
 
         # Обработка файлового контента
@@ -145,6 +203,5 @@ class MessageCommand:
         if file_content:
             question = f"{question}\n\n{file_content}" if question else file_content
 
-        await self.reply_func(
-            update=update, message=message, context=context, question=question
-        )
+        await self.reply_func(update=update, message=message, context=context, question=question)
+


### PR DESCRIPTION
## Summary
- debounce media group messages in message command
- aggregate photos before processing
- test photo albums are processed once

## Testing
- `CONFIG=config.example.yml python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c9d997f38832c877e5b31d026bed1