### PR TITLE
Handle local URLs and hide scrapdo token

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -282,6 +282,9 @@ async def reply_to(
     except Exception as exc:
         class_name = f"{exc.__class__.__module__}.{exc.__class__.__qualname__}"
         error_text = f"{class_name}: {exc}"
+        token = config.scrapdo.token
+        if token:
+            error_text = error_text.replace(token, "***")
         logger.error("Failed to answer: %s", error_text)
         text = textwrap.shorten(f"⚠️ {error_text}", width=255, placeholder="...")
         await message.reply_text(text)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -78,6 +78,11 @@ second
         urls = self.fetcher._extract_urls(text)
         self.assertEqual(urls, [])
 
+    def test_ignore_local_urls(self):
+        text = "Check http://localhost:8000/ and http://127.0.0.1/foo"
+        urls = self.fetcher._extract_urls(text)
+        self.assertEqual(urls, [])
+
     async def test_fetch_url(self):
         self.fetcher.client = FakeClient({"https://example.org/boom": RuntimeError("boom")})
         result = await self.fetcher._fetch_url("https://example.org/boom")


### PR DESCRIPTION
## Summary
- skip localhost/private URLs when substituting URLs
- mask scrap.do token in logged errors
- test localhost URL handling

## Testing
- `pytest tests/test_fetcher.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567aee10c4832cb11e9e333fc9c3b1